### PR TITLE
Fix: Read ressource returns None instead of ghost object if nothing found

### DIFF
--- a/src/pulse/api.py
+++ b/src/pulse/api.py
@@ -981,7 +981,7 @@ class Resource(PulseDbObject):
                         
                         # If resource not found, raise missing
                         if not source_resource:
-                            raise PulseDatabaseMissingObject
+                            raise PulseDatabaseMissingObject(f"Source ressource not found.")
                         
                         source_commit = source_resource.get_commit("last")
                 except PulseDatabaseMissingObject:

--- a/src/pulse/api.py
+++ b/src/pulse/api.py
@@ -978,6 +978,11 @@ class Resource(PulseDbObject):
                 try:
                     if self.entity != cfg.template_name:
                         source_resource = self.project.get_resource(cfg.template_name, self.resource_type)
+                        
+                        # If resource not found, raise missing
+                        if not source_resource:
+                            raise PulseDatabaseMissingObject
+                        
                         source_commit = source_resource.get_commit("last")
                 except PulseDatabaseMissingObject:
                     pass

--- a/src/pulse/api.py
+++ b/src/pulse/api.py
@@ -54,12 +54,18 @@ class PulseDbObject:
         """
             read all object attributes from database.
 
-            Will pass if the database have an attribute missing on the object
+            Will pass if the database have an attribute missing on the object.
+            Returns ``None`` if nothing found.
 
-            :return: PulseDbObject
+            :return: PulseDbObject or None
             :rtype: PulseDbObject
         """
         data = self.project.cnx.db.read(self.project.name, self.__class__.__name__, self.uri)
+        
+        # Check data is valid
+        if not data:
+            return
+
         for k in data:
             if k not in vars(self):
                 continue

--- a/src/pulse/api.py
+++ b/src/pulse/api.py
@@ -981,7 +981,7 @@ class Resource(PulseDbObject):
                         
                         # If resource not found, raise missing
                         if not source_resource:
-                            raise PulseDatabaseMissingObject(f"Source ressource not found.")
+                            raise PulseDatabaseMissingObject(f"Database object not found.")
                         
                         source_commit = source_resource.get_commit("last")
                 except PulseDatabaseMissingObject:


### PR DESCRIPTION
Allows to code:

```py
shot_anim = prj.get_resource("shot_99", "animation")
if not shot_anim:
    shot_anim = prj.create_resource("shot_99", "animation")
```